### PR TITLE
Fix mobile Safari usage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,7 @@ class VideoSnapshot {
       video.preload = 'metadata';
       video.src = this.videoUrl;
       video.muted = true;
+      video.setAttribute('playsinline', '');
 
       if (time === 0) {
         video.play();


### PR DESCRIPTION
It seems that `video-snapshot` isn't working on mobile Safari (you can test current demo page in iOS Safari or XCode iOS Simulator), so I added `playsinline` attribute to `video` element. Check solution link below.

Error:
![Screen Shot 2020-12-01 at 17 15 59](https://user-images.githubusercontent.com/16384428/100812476-db1ffc80-341b-11eb-9ccf-25ca2ba79263.png)

Solution:
http://support.temasys.com.sg/support/solutions/articles/12000038436-video-element-is-not-playing-on-ios-11-safari-mobile-browser

Docs:
https://webkit.org/blog/6784/new-video-policies-for-ios/
https://developer.mozilla.org/en-US/docs/Web/API/Element/setAttribute
https://css-tricks.com/what-does-playsinline-mean-in-web-video/




