### PR TITLE
Fix for non-H264 videos

### DIFF
--- a/__tests__/index.tsx
+++ b/__tests__/index.tsx
@@ -2,7 +2,8 @@ declare var global: any;
 import VideoSnapshot from '../src';
 
 describe('VideoSnapshot', () => {
-  const setup = () => {
+  const setup = (opts: { videoWith?: number; videoHeight?: number } = {}) => {
+    const { videoWith, videoHeight } = opts;
     const videoFile = new File([''], 'video.mp4');
     const createObjectURL = jest.fn().mockReturnValue('video-url');
     const revokeObjectURL = jest.fn();
@@ -23,12 +24,13 @@ describe('VideoSnapshot', () => {
       removeEventListener,
       play,
       pause,
-      videoWidth: 100,
-      width: 100,
-      videoHeight: 50,
-      height: 50,
+      videoWidth: typeof videoWith === "number" ? videoWith : 100,
+      width: typeof videoWith === "number" ? videoWith : 100,
+      videoHeight: typeof videoHeight === "number" ? videoHeight : 50,
+      height: typeof videoHeight === "number" ? videoHeight : 50,
       duration: 100,
     };
+
     const createElement = jest.fn().mockImplementation((type: string) => {
       if (type === 'video') {
         return video;
@@ -135,6 +137,19 @@ describe('VideoSnapshot', () => {
     } catch (error) {
       expect(error).toBeInstanceOf(Error);
       expect(error.message).toEqual('failed to load video')
+    }
+  });
+
+  it("should throw an error if the video has empty dimensions", async () => {
+    expect.assertions(2);
+    const { videoFile } = setup({ videoWith: 0, videoHeight: 0 });
+    const snapshoter = new VideoSnapshot(videoFile);
+
+    try {
+      await snapshoter.takeSnapshot();
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect(error.message).toEqual("error retrieving video dimensions");
     }
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,10 @@ class VideoSnapshot {
     const video = await this.loadVideo(time);
     const canvas = document.createElement('canvas');
 
+    if (!video.videoWidth && !video.videoHeight) {
+      throw new Error("error retrieving video dimensions");
+    }
+
     canvas.width = video.videoWidth;
     canvas.height = video.videoHeight;
     const context = canvas.getContext('2d');


### PR DESCRIPTION
I've noticed that when working with MP4/MOV files whose video codec isn't supported by the browser (I'm trying a MP4/MOV embedding HEVC for instance), the created `video` object would have empty dimensions, hence the library would create a canvas for nothing, draw nothing into it and return the string "data:;".

I suggest that we instead throw an error, assuming that our consumers are already catching them in a try/catch block.